### PR TITLE
Removed API keys

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 const config = {
 	Binance : {
-		APIKEY : 'yTGrczsnJIxGnlRTkmHW2dMAAcPoHNUtoqC2SgT5yWKnv2UFjQ7YaM4zP5zO1z1Q',
-		APISECRET : 'CcpnnqTMCu4S5pAEFcHsEMcVwEPuKyoqqo4ySbTm2LzSHRMTysDbtZ8FFIse1t7Z',
+		APIKEY : '',
+		APISECRET : '',
 	},
 	Currency : {
 		CURRENCY : 'ETHBTC',


### PR DESCRIPTION
You should not post your API keys on Github where anybody can access them and use them.

The history of your repository will still contain those keys, so this change is not sufficient.
You should revoke that API key in Binance so that nobody can use it.